### PR TITLE
Fire autocommands before and after writing files in :Acks

### DIFF
--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -125,7 +125,11 @@ function! ferret#private#acks(command) abort
   endif
 
   execute 'args' l:filenames
+
+  silent doautocmd User FerretWillWrite
   execute 'argdo' '%s' . a:command . 'ge | update'
+  silent doautocmd User FerretDidWrite
+
 endfunction
 
 " Populate the :args list with the filenames currently in the quickfix window.

--- a/doc/ferret.txt
+++ b/doc/ferret.txt
@@ -2,16 +2,17 @@
 
 CONTENTS                                                      *ferret-contents*
 
-1. Intro           |ferret-intro|
-2. Installation    |ferret-installation|
-3. Commands        |ferret-commands|
-4. Options         |ferret-options|
-5. Mappings        |ferret-mappings|
-6. Overrides       |ferret-overrides|
-7. Website         |ferret-website|
-8. License         |ferret-license|
-9. Authors         |ferret-authors|
-10. History        |ferret-history|
+1. Intro                 |ferret-intro|
+2. Installation          |ferret-installation|
+3. Commands              |ferret-commands|
+4. Options               |ferret-options|
+5. Mappings              |ferret-mappings|
+5. Custom autocommands   |ferret-custom-autocommands|
+7. Overrides             |ferret-overrides|
+8. Website               |ferret-website|
+9. License               |ferret-license|
+10. Authors              |ferret-authors|
+11. History              |ferret-history|
 
 
 INTRO                                                            *ferret-intro*
@@ -274,6 +275,25 @@ unless prevented from doing so by |g:FerretQFMap|:
   - `d` (|visual-mode|): delete visual selection
   - `dd` (|Normal-mode|): delete current line
   - `d`{motion} (|Normal-mode|): delete range indicated by {motion}
+
+
+CUSTOM AUTOCOMMANDS                                *ferret-custom-autocommands*
+
+                                               *FerretWillWrite* *FerretDidWrite*
+For maximum compatibility with other plug-ins, Ferret runs the following
+"User" autocommands before and after running the file writing operations
+during `:Acks`:
+
+FerretWillWrite
+FerretDidWrite
+
+For example, to call a pair of custom functions in response to these events,
+you might do: >
+
+   autocmd! User FerretWillWrite
+   autocmd User FerretWillWrite call CustomWillWrite()
+   autocmd! User FerretDidWrite
+   autocmd User FerretDidWrite call CustomDidWrite()
 
 
 OVERRIDES                                                    *ferret-overrides*


### PR DESCRIPTION
I use Syntastic, but don't want it to run when doing multi-file
find/replace via `:Acks` because it adds no value and it slows down the
operation considerably. To give users a good place to hook in to run
their own commands, I am adding FerretWillWrite and FerretDidWrite
`User` autocommands. This will allow me to add some configuration that
disables Syntastic for the operations that I care about.

I decided to use more generic names like `FerretWillWrite` and
`FerretDidWrite` instead of `FerretWillAcks` and `FerretDidAcks` because
I think it more clearly exposes the intent and timing of the
autocommands in the operation.

Fixes #2
