### PR TITLE
doc: Actually fix section numbering in table of contents

### DIFF
--- a/doc/ferret.txt
+++ b/doc/ferret.txt
@@ -8,11 +8,11 @@ CONTENTS                                                      *ferret-contents*
 4. Options               |ferret-options|
 5. Mappings              |ferret-mappings|
 6. Custom autocommands   |ferret-custom-autocommands|
-8. Overrides             |ferret-overrides|
-9. Website               |ferret-website|
-10. License              |ferret-license|
-11. Authors              |ferret-authors|
-12. History              |ferret-history|
+7. Overrides             |ferret-overrides|
+8. Website               |ferret-website|
+9. License               |ferret-license|
+10. Authors              |ferret-authors|
+11. History              |ferret-history|
 
 
 INTRO                                                            *ferret-intro*


### PR DESCRIPTION
I screwed this up in afa2868e, and then @wincent further screwed it up
in d9fd3f65.
