### PR TITLE
Highlight searched term

### DIFF
--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -66,6 +66,10 @@ endfunction
 
 function! ferret#private#ack(command) abort
   let g:ferret_lastsearch = s:escape(a:command)
+
+  let @/ = eval(s:escape(a:command))
+  call feedkeys(":let &hlsearch=1\<CR>", 'n')
+
   if empty(&grepprg)
     return
   endif
@@ -90,6 +94,9 @@ function! ferret#private#ack(command) abort
 endfunction
 
 function! ferret#private#lack(command) abort
+  let @/ = eval(s:escape(a:command))
+  call feedkeys(":let &hlsearch=1\<CR>", 'n')
+
   if empty(&grepprg)
     return
   endif


### PR DESCRIPTION
It looks like a user action is required to render the highlighting, hence `feedkeys()` has to be used (even though it is ugly).

Maybe add a setting for hl.
