### PR TITLE
Show quickfix/location list as vertical split on multiple splits (related to #13)

### DIFF
--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -195,15 +195,7 @@ function! ferret#private#ack(command) abort
     endtry
   else
     cexpr system(&grepprg . ' ' . l:command)
-
-    if l:pos == 'top'
-      topleft cwindow
-    elseif l:pos == 'bottom'
-      botright cwindow
-    else
-      cwindow
-    endif
-
+    execute g:FerretQHandler
     call ferret#private#post('qf')
   endif
 endfunction
@@ -217,7 +209,7 @@ function! ferret#private#lack(command) abort
   endif
 
   lexpr system(&grepprg . ' ' . l:command)
-  lwindow
+  execute g:FerretLHandler
   call ferret#private#post('location')
 endfunction
 

--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -164,7 +164,7 @@ endfunction
 
 function! ferret#private#ack(command) abort
   let l:command=s:parse(a:command)
-  let l:qhandler=get(g:, 'FerretQHandler', 'botright cwindow')
+  let l:qfhandler=get(g:, 'FerretQFHandler', 'botright cwindow')
 
   call ferret#private#hlsearch()
 
@@ -196,7 +196,7 @@ function! ferret#private#ack(command) abort
     endtry
   else
     cexpr system(&grepprg . ' ' . l:command)
-    execute l:qhandler
+    execute l:qfhandler
     call ferret#private#post('qf')
   endif
 endfunction

--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -164,7 +164,8 @@ endfunction
 
 function! ferret#private#ack(command) abort
   let l:command=s:parse(a:command)
-  let l:pos=get(g:, 'FerretPosition', 'bottom')
+  let l:qhandler=get(g:, 'FerretQHandler', 'botright cwindow')
+
   call ferret#private#hlsearch()
 
   if empty(&grepprg)
@@ -195,13 +196,14 @@ function! ferret#private#ack(command) abort
     endtry
   else
     cexpr system(&grepprg . ' ' . l:command)
-    execute g:FerretQHandler
+    execute l:qhandler
     call ferret#private#post('qf')
   endif
 endfunction
 
 function! ferret#private#lack(command) abort
   let l:command=s:parse(a:command)
+  let l:lhandler=get(g:, 'FerretLHandler', 'lwindow')
   call ferret#private#hlsearch()
 
   if empty(&grepprg)
@@ -209,7 +211,7 @@ function! ferret#private#lack(command) abort
   endif
 
   lexpr system(&grepprg . ' ' . l:command)
-  execute g:FerretLHandler
+  execute l:lhandler
   call ferret#private#post('location')
 endfunction
 

--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -164,6 +164,7 @@ endfunction
 
 function! ferret#private#ack(command) abort
   let l:command=s:parse(a:command)
+  let l:pos=get(g:, 'FerretPosition', 'bottom')
   call ferret#private#hlsearch()
 
   if empty(&grepprg)
@@ -194,7 +195,15 @@ function! ferret#private#ack(command) abort
     endtry
   else
     cexpr system(&grepprg . ' ' . l:command)
-    bo cwindow
+
+    if l:pos == 'top'
+      topleft cwindow
+    elseif l:pos == 'bottom'
+      botright cwindow
+    else
+      cwindow
+    endif
+
     call ferret#private#post('qf')
   endif
 endfunction
@@ -208,7 +217,7 @@ function! ferret#private#lack(command) abort
   endif
 
   lexpr system(&grepprg . ' ' . l:command)
-  bo lwindow
+  lwindow
   call ferret#private#post('location')
 endfunction
 

--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -194,7 +194,7 @@ function! ferret#private#ack(command) abort
     endtry
   else
     cexpr system(&grepprg . ' ' . l:command)
-    cwindow
+    bo cwindow
     call ferret#private#post('qf')
   endif
 endfunction
@@ -208,7 +208,7 @@ function! ferret#private#lack(command) abort
   endif
 
   lexpr system(&grepprg . ' ' . l:command)
-  lwindow
+  bo lwindow
   call ferret#private#post('location')
 endfunction
 

--- a/doc/ferret.txt
+++ b/doc/ferret.txt
@@ -234,6 +234,21 @@ OPTIONS                                                        *ferret-options*
 
     let g:FerretQFOptions=0
 <
+                                                            *g:FerretQFHandler*
+  |g:FerretQFHandler|                      string (default: 'botright cwindow')
+
+  Defines the command to open the the |quickfix| window.
+
+  It can be useful if you want to define how many lines the |quickfix| window
+  should have. For example: >
+
+    let g:FerretQFHandler='botright cwindow 30'
+<
+                                                             *g:FerretLHandler*
+  |g:FerretLHandler|                       string (default: 'botright lwindow')
+
+  Just like |g:FerretQFHandler|, but applied to |location-list|.
+
                                                                *g:FerretLoaded*
   |g:FerretLoaded|                                             any (no default)
 
@@ -241,7 +256,7 @@ OPTIONS                                                        *ferret-options*
   |.vimrc|. For example: >
 
     let g:FerretLoaded=1
-
+<
 
 MAPPINGS                                                      *ferret-mappings*
 

--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -8,6 +8,9 @@ if exists('g:FerretLoaded') || &compatible || v:version < 700
 endif
 let g:FerretLoaded = 1
 
+let g:FerretQHandler = get(g:, 'FerretQHandler', 'botright cwindow')
+let g:FerretLHandler = get(g:, 'FerretLHandler', 'lwindow')
+
 " Temporarily set 'cpoptions' to Vim default as per `:h use-cpo-save`.
 let s:cpoptions = &cpoptions
 set cpoptions&vim

--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -8,9 +8,6 @@ if exists('g:FerretLoaded') || &compatible || v:version < 700
 endif
 let g:FerretLoaded = 1
 
-let g:FerretQHandler = get(g:, 'FerretQHandler', 'botright cwindow')
-let g:FerretLHandler = get(g:, 'FerretLHandler', 'lwindow')
-
 " Temporarily set 'cpoptions' to Vim default as per `:h use-cpo-save`.
 let s:cpoptions = &cpoptions
 set cpoptions&vim


### PR DESCRIPTION
This fix will make the Ferret split occupy the entire window horizontally, like [CtrlP](https://github.com/ctrlpvim/ctrlp.vim).

If it's necessary, I can make it optional, or make it possible to show on top instead of bottom as an option. Just tell me and I'll modify it :)
