### PR TITLE
Fix grepprg parameters when using ag or ack with a specific file/directory

### DIFF
--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -13,9 +13,9 @@ let s:cpoptions = &cpoptions
 set cpoptions&vim
 
 if executable('ag') " The Silver Searcher: faster than ack.
-  let s:ackprg = 'ag --column --nocolor --nogroup'
+  let s:ackprg = 'ag --vimgrep'
 elseif executable('ack') " Ack: better than grep.
-  let s:ackprg = 'ack --column'
+  let s:ackprg = 'ack --column --nocolor --nogroup --with-filename'
 elseif executable('grep') " Grep: it's just grep.
   let s:ackprg = &grepprg " default is: grep -n $* /dev/null
 endif

--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -15,7 +15,7 @@ set cpoptions&vim
 if executable('ag') " The Silver Searcher: faster than ack.
   let s:ackprg = 'ag --vimgrep'
 elseif executable('ack') " Ack: better than grep.
-  let s:ackprg = 'ack --column --nocolor --nogroup --with-filename'
+  let s:ackprg = 'ack --column --with-filename'
 elseif executable('grep') " Grep: it's just grep.
   let s:ackprg = &grepprg " default is: grep -n $* /dev/null
 endif


### PR DESCRIPTION
Well... the title says everything. When using `:Ack` with a second argument (the file/directory to be searched) it was giving an invalid syntax for `grepformat` for both `ag` and `ack` programs.

This pull request changes some parameters to make things work as expected in this situation (and maybe some other situations for `ag`, as I'm using the `--vimgrep` option that exists only for the purpose of integrating with Vim).
