### PR TITLE
Use fixed-height in test.rb

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -43,7 +43,7 @@ module DSL
 
   def session(name, &block)
     escaped_name = DSL.escape(name)
-    %x{tmux new-session -d -s #{DSL.escape(escaped_name)}}
+    %x{tmux new-session -d -s #{DSL.escape(escaped_name)} -y 20}
     Session.new(escaped_name).instance_eval(&block)
     %x{tmux kill-session -t #{escaped_name}}
   end


### PR DESCRIPTION
When running test.rb in a very short terminal window, sometimes the
expected output ("module DSL") does not fit within the initial view, and
thus the test script fails.

By using a fixed height we can isolate against failures from this
cause... even though I am not sure if this script is still maintained.