### PR TITLE
Remove superfluous autocommands that open quickfix/loclist

### DIFF
--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -455,14 +455,6 @@ if !empty(s:executable)
   let &grepformat=g:FerretFormat
 endif
 
-if has('autocmd')
-  augroup Ferret
-    autocmd!
-    autocmd QuickFixCmdPost [^l]* nested cwindow
-    autocmd QuickFixCmdPost l* nested lwindow
-  augroup END
-endif
-
 ""
 " @command :Ack {pattern} {options}
 "


### PR DESCRIPTION
According to documentation 'QuickFixCmdPost' runs after a quickfix
command is run before jumping to the first location. However, `cwindow`
or `lwindow` are already called sans-autocommand by
`ferret#private#vanilla#finalize_search` on completion of the search.

The global autocommand can wreak havoc on other plugins which populate
the quickfix list and intend to display it with their own callback
(since the QuickFixCmdPost autocommand will run between a `caddexpr` and
the same plugin's `cwindow` calls).

I tested `:Ack`, `:Lack`, `:Acks` and they seem to be working pretty
well, though I suppose it's possible that there is some subtle change I
didn't notice.