### PR TITLE
Set the list's 'title' with last search string

### DIFF
--- a/autoload/ferret/private/shared.vim
+++ b/autoload/ferret/private/shared.vim
@@ -26,7 +26,20 @@ function! s:autojump()
   return l:autojump
 endfunction
 
+function! s:settitle(type, title) abort
+  if has('patch-7.4.2200')
+    if a:type ==# 'qf'
+      call setqflist([], 'a', {'title' : a:title})
+    else
+      call setloclist(0, [], 'a', {'title' : a:title})
+    endif
+  elseif a:type ==# 'qf'
+    let w:quickfix_title = a:title
+  endif
+endfunction
+
 function! ferret#private#shared#finalize_search(output, ack)
+  let l:lastsearch = get(g:, 'ferret_lastsearch', '')
   let l:original_errorformat=&errorformat
   let l:autojump=s:autojump()
   if a:ack
@@ -45,6 +58,7 @@ function! ferret#private#shared#finalize_search(output, ack)
     else
       call s:swallow(l:prefix . 'getexpr a:1', a:output)
     endif
+    call s:settitle(l:post, 'Search `' . l:lastsearch . '`')
     let l:before=winnr()
     let l:len=ferret#private#post(l:post)
     if l:len

--- a/doc/ferret.txt
+++ b/doc/ferret.txt
@@ -650,6 +650,7 @@ order):
 - Daniel Silva
 - Filip Szymański
 - Joe Lencioni
+- Jon Parise
 - Nelo-Thara Wallus
 - Tom Dooner
 - Vaibhav Sagar


### PR DESCRIPTION
We create the list using e.g. `cexpr`, which implicitly names the list
after the command that created it. We can provide a more descriptive
title by setting the list's 'title' field (in vim 7.4.2200+) or setting
`w:quickfix_title` as a fallback (just for the quickfix list).