### PR TITLE
Use `normal!` instead of `normal`.

### DIFF
--- a/autoload/ferret/private.vim
+++ b/autoload/ferret/private.vim
@@ -34,7 +34,7 @@ function! s:delete(first, last)
   endif
 
   " Move focus back to listing.
-  execute "normal \<C-W>\<C-P>"
+  execute "normal! \<C-W>\<C-P>"
 endfunction
 
 " Returns 1 if we should use Neovim's |job-control| features.

--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -850,10 +850,10 @@ command! -bar Largs execute 'args' ferret#private#args('location')
 let s:commands=get(g:, 'FerretQFCommands', 1)
 if s:commands
   " Keep quickfix result centered, if possible, when jumping from result to result.
-  cabbrev <silent> <expr> cn ((getcmdtype() == ':' && getcmdpos() == 3) ? 'cn <bar> normal zz' : 'cn')
-  cabbrev <silent> <expr> cnf ((getcmdtype() == ':' && getcmdpos() == 4) ? 'cnf <bar> normal zz' : 'cnf')
-  cabbrev <silent> <expr> cp ((getcmdtype() == ':' && getcmdpos() == 3) ? 'cp <bar> normal zz' : 'cp')
-  cabbrev <silent> <expr> cpf ((getcmdtype() == ':' && getcmdpos() == 4) ? 'cpf <bar> normal zz' : 'cpf')
+  cabbrev <silent> <expr> cn ((getcmdtype() == ':' && getcmdpos() == 3) ? 'cn <bar> normal! zz' : 'cn')
+  cabbrev <silent> <expr> cnf ((getcmdtype() == ':' && getcmdpos() == 4) ? 'cnf <bar> normal! zz' : 'cnf')
+  cabbrev <silent> <expr> cp ((getcmdtype() == ':' && getcmdpos() == 3) ? 'cp <bar> normal! zz' : 'cp')
+  cabbrev <silent> <expr> cpf ((getcmdtype() == ':' && getcmdpos() == 4) ? 'cpf <bar> normal! zz' : 'cpf')
 endif
 
 ""


### PR DESCRIPTION
This avoids remapping the commands by custom user mappings.