### PR TITLE
Typo in option documentation: FerrerLazyInit

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ let g:FerretLoaded=1
 In order to minimize impact on Vim start-up time Ferret will initialize itself lazily on first use by default. If you wish to force immediate initialization (for example, to cause <strong>`'grepprg'`</strong> and <strong>`'grepformat'`</strong> to be set as soon as Vim launches), then set <strong>[`g:FerretLazyInit`](#user-content-gferretlazyinit)</strong> to 0 in your <strong>`.vimrc`</strong>:
 
 ```
-let g:FerrerLazyInit=0
+let g:FerretLazyInit=0
 ```
 
 <p align="right"><a name="gferretackwordword" href="#user-content-gferretackwordword"><code>g:FerretAckWordWord</code></a></p>

--- a/doc/ferret.txt
+++ b/doc/ferret.txt
@@ -531,7 +531,7 @@ itself lazily on first use by default. If you wish to force immediate
 initialization (for example, to cause |'grepprg'| and |'grepformat'| to be set
 as soon as Vim launches), then set |g:FerretLazyInit| to 0 in your |.vimrc|:
 >
-    let g:FerrerLazyInit=0
+    let g:FerretLazyInit=0
 <
 
                                                            *g:FerretAckWordWord*

--- a/plugin/ferret.vim
+++ b/plugin/ferret.vim
@@ -560,7 +560,7 @@ set cpoptions&vim
 " launches), then set |g:FerretLazyInit| to 0 in your |.vimrc|:
 "
 " ```
-" let g:FerrerLazyInit=0
+" let g:FerretLazyInit=0
 " ```
 if !get(g:, 'FerretLazyInit', 1)
   call ferret#private#init()


### PR DESCRIPTION
Fixes a typo which occurs several times in the documentation:

`g:FerrerLazyInit` => `g:FerretLazyInit` 